### PR TITLE
Renamed some Modifier enum names

### DIFF
--- a/csharp/StdUriTemplate.cs
+++ b/csharp/StdUriTemplate.cs
@@ -19,12 +19,12 @@ public class StdUriTemplate
     {
         NO_MOD,
         PLUS,
-        DASH,
+        HASH,
         DOT,
         SLASH,
         SEMICOLON,
         QUESTION_MARK,
-        AT
+        AMP
     }
 
     private static void ValidateLiteral(char c, int col)
@@ -74,12 +74,12 @@ public class StdUriTemplate
         switch (c)
         {
             case '+': return Modifier.PLUS;
-            case '#': return Modifier.DASH;
+            case '#': return Modifier.HASH;
             case '.': return Modifier.DOT;
             case '/': return Modifier.SLASH;
             case ';': return Modifier.SEMICOLON;
             case '?': return Modifier.QUESTION_MARK;
-            case '&': return Modifier.AT;
+            case '&': return Modifier.AMP;
             default:
                 ValidateLiteral(c, col);
                 token.Append(c);
@@ -197,7 +197,7 @@ public class StdUriTemplate
     {
         switch (mod)
         {
-            case Modifier.DASH:
+            case Modifier.HASH:
                 result.Append('#');
                 break;
             case Modifier.DOT:
@@ -212,7 +212,7 @@ public class StdUriTemplate
             case Modifier.QUESTION_MARK:
                 result.Append('?');
                 break;
-            case Modifier.AT:
+            case Modifier.AMP:
                 result.Append('&');
                 break;
             default:
@@ -234,7 +234,7 @@ public class StdUriTemplate
                 result.Append(';');
                 break;
             case Modifier.QUESTION_MARK:
-            case Modifier.AT:
+            case Modifier.AMP:
                 result.Append('&');
                 break;
             default:
@@ -248,11 +248,11 @@ public class StdUriTemplate
         switch (mod)
         {
             case Modifier.PLUS:
-            case Modifier.DASH:
+            case Modifier.HASH:
                 AddExpandedValue(value, result, maxChar, false);
                 break;
             case Modifier.QUESTION_MARK:
-            case Modifier.AT:
+            case Modifier.AMP:
                 result.Append(token + '=');
                 AddExpandedValue(value, result, maxChar, true);
                 break;
@@ -277,11 +277,11 @@ public class StdUriTemplate
         switch (mod)
         {
             case Modifier.PLUS:
-            case Modifier.DASH:
+            case Modifier.HASH:
                 AddExpandedValue(value, result, maxChar, false);
                 break;
             case Modifier.QUESTION_MARK:
-            case Modifier.AT:
+            case Modifier.AMP:
             case Modifier.SEMICOLON:
             case Modifier.DOT:
             case Modifier.SLASH:

--- a/go/stduritemplate.go
+++ b/go/stduritemplate.go
@@ -23,12 +23,12 @@ const (
 	ModUndefined    Mod = 0
 	ModNone         Mod = -1
 	ModPlus         Mod = '+'
-	ModDash         Mod = '#'
+	ModHash         Mod = '#'
 	ModDot          Mod = '.'
 	ModSlash        Mod = '/'
 	ModSemicolon    Mod = ';'
 	ModQuestionMark Mod = '?'
-	ModAt           Mod = '&'
+	ModAmp          Mod = '&'
 )
 
 const (
@@ -68,7 +68,7 @@ func getModifier(c rune, token *strings.Builder, col int) (Mod, error) {
 	case '+':
 		return ModPlus, nil
 	case '#':
-		return ModDash, nil
+		return ModHash, nil
 	case '.':
 		return ModDot, nil
 	case '/':
@@ -78,7 +78,7 @@ func getModifier(c rune, token *strings.Builder, col int) (Mod, error) {
 	case '?':
 		return ModQuestionMark, nil
 	case '&':
-		return ModAt, nil
+		return ModAmp, nil
 	default:
 		err := validateLiteral(c, col)
 		if err != nil {
@@ -186,7 +186,7 @@ func expandImpl(str string, substitutions Substitutions) (string, error) {
 
 func addPrefix(mod Mod, result *strings.Builder) {
 	switch mod {
-	case ModDash, ModDot, ModSlash, ModSemicolon, ModQuestionMark, ModAt:
+	case ModHash, ModDot, ModSlash, ModSemicolon, ModQuestionMark, ModAmp:
 		result.WriteRune(rune(mod))
 	default:
 		return
@@ -197,7 +197,7 @@ func addSeparator(mod Mod, result *strings.Builder) {
 	switch mod {
 	case ModDot, ModSlash, ModSemicolon:
 		result.WriteRune(rune(mod))
-	case ModQuestionMark, ModAt:
+	case ModQuestionMark, ModAmp:
 		result.WriteByte('&')
 	default:
 		result.WriteByte(',')
@@ -207,9 +207,9 @@ func addSeparator(mod Mod, result *strings.Builder) {
 
 func addValue(mod Mod, token, value string, result *strings.Builder, maxChar int) {
 	switch mod {
-	case ModPlus, ModDash:
+	case ModPlus, ModHash:
 		addExpandedValue(value, result, maxChar, false)
-	case ModQuestionMark, ModAt:
+	case ModQuestionMark, ModAmp:
 		result.WriteString(token + "=")
 		addExpandedValue(value, result, maxChar, true)
 	case ModSemicolon:
@@ -225,9 +225,9 @@ func addValue(mod Mod, token, value string, result *strings.Builder, maxChar int
 
 func addValueElement(mod Mod, _, value string, result *strings.Builder, maxChar int) {
 	switch mod {
-	case ModPlus, ModDash:
+	case ModPlus, ModHash:
 		addExpandedValue(value, result, maxChar, false)
-	case ModQuestionMark, ModAt, ModSemicolon, ModDot, ModSlash, ModNone:
+	case ModQuestionMark, ModAmp, ModSemicolon, ModDot, ModSlash, ModNone:
 		addExpandedValue(value, result, maxChar, true)
 	}
 }

--- a/java/.gitignore
+++ b/java/.gitignore
@@ -2,3 +2,6 @@ target
 .idea
 test.jar
 lib
+.classpath
+.project
+.settings

--- a/java/src/main/java/io/github/stduritemplate/StdUriTemplate.java
+++ b/java/src/main/java/io/github/stduritemplate/StdUriTemplate.java
@@ -23,12 +23,12 @@ public class StdUriTemplate {
     private enum Modifier {
         NO_MOD,
         PLUS,
-        DASH,
+        HASH,
         DOT,
         SLASH,
         SEMICOLON,
         QUESTION_MARK,
-        AT;
+        AMP;
     }
 
     private static void validateLiteral(Character c, int col) {
@@ -75,12 +75,12 @@ public class StdUriTemplate {
     private static Modifier getModifier(Character c, StringBuilder token, int col) {
         switch (c) {
             case '+': return Modifier.PLUS;
-            case '#': return Modifier.DASH;
+            case '#': return Modifier.HASH;
             case '.': return Modifier.DOT;
             case '/': return Modifier.SLASH;
             case ';': return Modifier.SEMICOLON;
             case '?': return Modifier.QUESTION_MARK;
-            case '&': return Modifier.AT;
+            case '&': return Modifier.AMP;
             default:
                 validateLiteral(c, col);
                 token.append(c);
@@ -167,7 +167,7 @@ public class StdUriTemplate {
 
     private static void addPrefix(Modifier mod, StringBuilder result) {
         switch (mod) {
-            case DASH:
+            case HASH:
                 result.append('#');
                 break;
             case DOT:
@@ -182,7 +182,7 @@ public class StdUriTemplate {
             case QUESTION_MARK:
                 result.append('?');
                 break;
-            case AT:
+            case AMP:
                 result.append('&');
                 break;
             default:
@@ -202,7 +202,7 @@ public class StdUriTemplate {
                 result.append(';');
                 break;
             case QUESTION_MARK:
-            case AT:
+            case AMP:
                 result.append('&');
                 break;
             default:
@@ -214,11 +214,11 @@ public class StdUriTemplate {
     private static void addValue(Modifier mod, String token, String value, StringBuilder result, int maxChar) {
         switch (mod) {
             case PLUS:
-            case DASH:
+            case HASH:
                 addExpandedValue(value, result, maxChar, false);
                 break;
             case QUESTION_MARK:
-            case AT:
+            case AMP:
                 result.append(token + '=');
                 addExpandedValue(value, result, maxChar, true);
                 break;
@@ -239,11 +239,11 @@ public class StdUriTemplate {
     private static void addValueElement(Modifier mod, String token, String value, StringBuilder result, int maxChar) {
         switch (mod) {
             case PLUS:
-            case DASH:
+            case HASH:
                 addExpandedValue(value, result, maxChar, false);
                 break;
             case QUESTION_MARK:
-            case AT:
+            case AMP:
             case SEMICOLON:
             case DOT:
             case SLASH:

--- a/php/src/StdUriTemplate.php
+++ b/php/src/StdUriTemplate.php
@@ -51,12 +51,12 @@ class StdUriTemplate {
     private static function getModifier($c, &$token, $col) {
         switch ($c) {
             case '+': return 'PLUS';
-            case '#': return 'DASH';
+            case '#': return 'HASH';
             case '.': return 'DOT';
             case '/': return 'SLASH';
             case ';': return 'SEMICOLON';
             case '?': return 'QUESTION_MARK';
-            case '&': return 'AT';
+            case '&': return 'AMP';
             default:
                 self::validateLiteral($c, $col);
                 $token .= $c;
@@ -142,7 +142,7 @@ class StdUriTemplate {
 
     private static function addPrefix($mod, &$result) {
         switch ($mod) {
-            case 'DASH':
+            case 'HASH':
                 $result .= '#';
                 break;
             case 'DOT':
@@ -157,7 +157,7 @@ class StdUriTemplate {
             case 'QUESTION_MARK':
                 $result .= '?';
                 break;
-            case 'AT':
+            case 'AMP':
                 $result .= '&';
                 break;
             default:
@@ -177,7 +177,7 @@ class StdUriTemplate {
                 $result .= ';';
                 break;
             case 'QUESTION_MARK':
-            case 'AT':
+            case 'AMP':
                 $result .= '&';
                 break;
             default:
@@ -189,11 +189,11 @@ class StdUriTemplate {
     private static function addValue($mod, $token, $value, &$result, $maxChar) {
         switch ($mod) {
             case 'PLUS':
-            case 'DASH':
+            case 'HASH':
                 self::addExpandedValue($value, $result, $maxChar, false);
                 break;
             case 'QUESTION_MARK':
-            case 'AT':
+            case 'AMP':
 
                 $result .= $token . '=';
                 self::addExpandedValue($value, $result, $maxChar, true);
@@ -215,11 +215,11 @@ class StdUriTemplate {
     private static function addValueElement($mod, $token, $value, &$result, $maxChar) {
         switch ($mod) {
             case 'PLUS':
-            case 'DASH':
+            case 'HASH':
                 self::addExpandedValue($value, $result, $maxChar, false);
                 break;
             case 'QUESTION_MARK':
-            case 'AT':
+            case 'AMP':
             case 'SEMICOLON':
             case 'DOT':
             case 'SLASH':

--- a/python/stduritemplate/__init__.py
+++ b/python/stduritemplate/__init__.py
@@ -6,12 +6,12 @@ from enum import Enum
 
 class _Modifier(Enum):
     PLUS = "+"
-    DASH = "#"
+    HASH = "#"
     DOT = "."
     SLASH = "/"
     SEMICOLON = ";"
     QUESTION_MARK = "?"
-    AT = "&"
+    AMP = "&"
     NO_MOD = ""
 
 
@@ -64,7 +64,7 @@ class StdUriTemplate:
         if character == "+":
             return _Modifier.PLUS
         elif character == "#":
-            return _Modifier.DASH
+            return _Modifier.HASH
         elif character == ".":
             return _Modifier.DOT
         elif character == "/":
@@ -74,7 +74,7 @@ class StdUriTemplate:
         elif character == "?":
             return _Modifier.QUESTION_MARK
         elif character == "&":
-            return _Modifier.AT
+            return _Modifier.AMP
         else:
             StdUriTemplate.__validate_literal(character, col)
             token.append(character)
@@ -161,7 +161,7 @@ class StdUriTemplate:
 
     @staticmethod
     def __add_prefix(mod: str, result: List[str]) -> None:
-        if mod == _Modifier.DASH:
+        if mod == _Modifier.HASH:
             result.append("#")
         elif mod == _Modifier.DOT:
             result.append(".")
@@ -171,7 +171,7 @@ class StdUriTemplate:
             result.append(";")
         elif mod == _Modifier.QUESTION_MARK:
             result.append("?")
-        elif mod == _Modifier.AT:
+        elif mod == _Modifier.AMP:
             result.append("&")
 
     @staticmethod
@@ -182,7 +182,7 @@ class StdUriTemplate:
             result.append("/")
         elif mod == _Modifier.SEMICOLON:
             result.append(";")
-        elif mod == _Modifier.QUESTION_MARK or mod == _Modifier.AT:
+        elif mod == _Modifier.QUESTION_MARK or mod == _Modifier.AMP:
             result.append("&")
         else:
             result.append(",")
@@ -191,9 +191,9 @@ class StdUriTemplate:
     def __add_value(
         mod: str, token: str, value: str, result: List[str], max_char: int
     ) -> None:
-        if mod == _Modifier.PLUS or mod == _Modifier.DASH:
+        if mod == _Modifier.PLUS or mod == _Modifier.HASH:
             StdUriTemplate.__add_expanded_value(value, result, max_char, False)
-        elif mod == _Modifier.QUESTION_MARK or mod == _Modifier.AT:
+        elif mod == _Modifier.QUESTION_MARK or mod == _Modifier.AMP:
             result.append(token + "=")
             StdUriTemplate.__add_expanded_value(value, result, max_char, True)
         elif mod == _Modifier.SEMICOLON:
@@ -208,11 +208,11 @@ class StdUriTemplate:
     def __add_value_element(
         mod: str, token: str, value: str, result: List[str], max_char: int
     ) -> None:
-        if mod == _Modifier.PLUS or mod == _Modifier.DASH:
+        if mod == _Modifier.PLUS or mod == _Modifier.HASH:
             StdUriTemplate.__add_expanded_value(value, result, max_char, False)
         elif (
             mod == _Modifier.QUESTION_MARK
-            or mod == _Modifier.AT
+            or mod == _Modifier.AMP
             or mod == _Modifier.SEMICOLON
             or mod == _Modifier.DOT
             or mod == _Modifier.SLASH

--- a/ruby/lib/StdUriTemplate.rb
+++ b/ruby/lib/StdUriTemplate.rb
@@ -13,12 +13,12 @@ module StdUriTemplate
   module Modifier
     NO_MOD = :no_mod
     PLUS = :plus
-    DASH = :dash
+    HASH = :hash
     DOT = :dot
     SLASH = :slash
     SEMICOLON = :semicolon
     QUESTION_MARK = :question_mark
-    AT = :at
+    AMP = :amp
   end
 
   def self.validate_literal(c, col)
@@ -49,7 +49,7 @@ module StdUriTemplate
     when '+'
       Modifier::PLUS
     when '#'
-      Modifier::DASH
+      Modifier::HASH
     when '.'
       Modifier::DOT
     when '/'
@@ -59,7 +59,7 @@ module StdUriTemplate
     when '?'
       Modifier::QUESTION_MARK
     when '&'
-      Modifier::AT
+      Modifier::AMP
     else
       validate_literal(c, col)
       token << c
@@ -134,7 +134,7 @@ module StdUriTemplate
 
   def self.add_prefix(mod, result)
     case mod
-    when Modifier::DASH
+    when Modifier::HASH
       result << '#'
     when Modifier::DOT
       result << '.'
@@ -144,7 +144,7 @@ module StdUriTemplate
       result << ';'
     when Modifier::QUESTION_MARK
       result << '?'
-    when Modifier::AT
+    when Modifier::AMP
       result << '&'
     end
   end
@@ -157,7 +157,7 @@ module StdUriTemplate
       result << '/'
     when Modifier::SEMICOLON
       result << ';'
-    when Modifier::QUESTION_MARK, Modifier::AT
+    when Modifier::QUESTION_MARK, Modifier::AMP
       result << '&'
     else
       result << ','
@@ -166,9 +166,9 @@ module StdUriTemplate
 
   def self.add_value(mod, token, value, result, max_char)
     case mod
-    when Modifier::PLUS, Modifier::DASH
+    when Modifier::PLUS, Modifier::HASH
       add_expanded_value(value, result, max_char, false)
-    when Modifier::QUESTION_MARK, Modifier::AT
+    when Modifier::QUESTION_MARK, Modifier::AMP
       result << token + '='
       add_expanded_value(value, result, max_char, true)
     when Modifier::SEMICOLON
@@ -182,9 +182,9 @@ module StdUriTemplate
 
   def self.add_value_element(mod, token, value, result, max_char)
     case mod
-    when Modifier::PLUS, Modifier::DASH
+    when Modifier::PLUS, Modifier::HASH
       add_expanded_value(value, result, max_char, false)
-    when Modifier::QUESTION_MARK, Modifier::AT, Modifier::SEMICOLON, Modifier::DOT, Modifier::SLASH, Modifier::NO_MOD
+    when Modifier::QUESTION_MARK, Modifier::AMP, Modifier::SEMICOLON, Modifier::DOT, Modifier::SLASH, Modifier::NO_MOD
       add_expanded_value(value, result, max_char, true)
     end
   end

--- a/swift/stduritemplate/Sources/stduritemplate/StdUriTemplate.swift
+++ b/swift/stduritemplate/Sources/stduritemplate/StdUriTemplate.swift
@@ -11,12 +11,12 @@ public class StdUriTemplate {
     private enum Modifier {
         case NO_MOD
         case PLUS
-        case DASH
+        case HASH
         case DOT
         case SLASH
         case SEMICOLON
         case QUESTION_MARK
-        case AT
+        case AMP
     }
     
     private static func validateLiteral(_ c: Character, _ col: Int) throws {
@@ -45,12 +45,12 @@ public class StdUriTemplate {
     private static func getModifier(_ c: Character, _ token: inout String, _ col: Int) throws -> Modifier {
         switch c {
             case "+": return .PLUS
-            case "#": return .DASH
+            case "#": return .HASH
             case ".": return .DOT
             case "/": return .SLASH
             case ";": return .SEMICOLON
             case "?": return .QUESTION_MARK
-            case "&": return .AT
+            case "&": return .AMP
             default:
                 try validateLiteral(c, col)
                 token.append(c)
@@ -131,7 +131,7 @@ public class StdUriTemplate {
     
     private static func addPrefix(_ mod: Modifier, _ result: inout String) {
         switch mod {
-            case .DASH:
+            case .HASH:
                 result.append("#")
             case .DOT:
                 result.append(".")
@@ -141,7 +141,7 @@ public class StdUriTemplate {
                 result.append(";")
             case .QUESTION_MARK:
                 result.append("?")
-            case .AT:
+            case .AMP:
                 result.append("&")
             default:
                 return
@@ -156,7 +156,7 @@ public class StdUriTemplate {
                 result.append("/")
             case .SEMICOLON:
                 result.append(";")
-            case .QUESTION_MARK, .AT:
+            case .QUESTION_MARK, .AMP:
                 result.append("&")
             default:
                 result.append(",")
@@ -166,9 +166,9 @@ public class StdUriTemplate {
     
     private static func addValue(_ mod: Modifier, _ token: String, _ value: String, _ result: inout String, _ maxChar: Int) {
         switch mod {
-            case .PLUS, .DASH:
+            case .PLUS, .HASH:
                 addExpandedValue(value, &result, maxChar, replaceReserved: false)
-            case .QUESTION_MARK, .AT:
+            case .QUESTION_MARK, .AMP:
                 result.append(token + "=")
                 addExpandedValue(value, &result, maxChar, replaceReserved: true)
             case .SEMICOLON:
@@ -184,9 +184,9 @@ public class StdUriTemplate {
     
     private static func addValueElement(_ mod: Modifier, _ token: String, _ value: String, _ result: inout String, _ maxChar: Int) {
         switch mod {
-            case .PLUS, .DASH:
+            case .PLUS, .HASH:
                 addExpandedValue(value, &result, maxChar, replaceReserved: false)
-            case .QUESTION_MARK, .AT, .SEMICOLON, .DOT, .SLASH, .NO_MOD:
+            case .QUESTION_MARK, .AMP, .SEMICOLON, .DOT, .SLASH, .NO_MOD:
                 addExpandedValue(value, &result, maxChar, replaceReserved: true)
         }
     }

--- a/typescript/src/index.ts
+++ b/typescript/src/index.ts
@@ -3,12 +3,12 @@ type Substitutions = { [key: string]: any };
 enum Modifier {
   NO_MOD,
   PLUS,
-  DASH,
+  HASH,
   DOT,
   SLASH,
   SEMICOLON,
   QUESTION_MARK,
-  AT,
+  AMP,
 }
 
 enum SubstitutionType {
@@ -68,7 +68,7 @@ export class StdUriTemplate {
       case '+':
         return Modifier.PLUS;
       case '#':
-        return Modifier.DASH;
+        return Modifier.HASH;
       case '.':
         return Modifier.DOT;
       case '/':
@@ -78,7 +78,7 @@ export class StdUriTemplate {
       case '?':
         return Modifier.QUESTION_MARK;
       case '&':
-        return Modifier.AT;
+        return Modifier.AMP;
       default:
         StdUriTemplate.validateLiteral(c, col);
         token.push(c);
@@ -181,7 +181,7 @@ export class StdUriTemplate {
 
   private static addPrefix(mod: Modifier | null, result: string[]): void {
     switch (mod) {
-      case Modifier.DASH:
+      case Modifier.HASH:
         result.push('#');
         break;
       case Modifier.DOT:
@@ -196,7 +196,7 @@ export class StdUriTemplate {
       case Modifier.QUESTION_MARK:
         result.push('?');
         break;
-      case Modifier.AT:
+      case Modifier.AMP:
         result.push('&');
         break;
       default:
@@ -216,7 +216,7 @@ export class StdUriTemplate {
         result.push(';');
         break;
       case Modifier.QUESTION_MARK:
-      case Modifier.AT:
+      case Modifier.AMP:
         result.push('&');
         break;
       default:
@@ -228,11 +228,11 @@ export class StdUriTemplate {
   private static addValue(mod: Modifier | null, token: string, value: string, result: string[], maxChar: number): void {
     switch (mod) {
       case Modifier.PLUS:
-      case Modifier.DASH:
+      case Modifier.HASH:
         StdUriTemplate.addExpandedValue(value, result, maxChar, false);
         break;
       case Modifier.QUESTION_MARK:
-      case Modifier.AT:
+      case Modifier.AMP:
         result.push(`${token}=`);
         StdUriTemplate.addExpandedValue(value, result, maxChar, true);
         break;
@@ -254,11 +254,11 @@ export class StdUriTemplate {
   private static addValueElement(mod: Modifier | null, token: string, value: string, result: string[], maxChar: number): void {
     switch (mod) {
       case Modifier.PLUS:
-      case Modifier.DASH:
+      case Modifier.HASH:
         StdUriTemplate.addExpandedValue(value, result, maxChar, false);
         break;
       case Modifier.QUESTION_MARK:
-      case Modifier.AT:
+      case Modifier.AMP:
       case Modifier.SEMICOLON:
       case Modifier.DOT:
       case Modifier.SLASH:


### PR DESCRIPTION
Two of the modifier names were, IMO, not correct.  This is a highly pedantic pull request to rename those modifier enum names to be more accurate.  :)

Note: I am only comfortable in a couple of these languages - in particular I'm not 100% sure of the Ruby changes.  I assume that the values in the `Modifier` module are just arbitrary labels and not some sort of language specific codes...