### PR TITLE
Add missing scope to dependabot automerge

### DIFF
--- a/.github/workflows/dependabot-automerge.yaml
+++ b/.github/workflows/dependabot-automerge.yaml
@@ -5,6 +5,7 @@ on: pull_request
 permissions:
   contents: write
   pull-requests: write
+  repository-projects: write
 
 jobs:
   dependabot:


### PR DESCRIPTION
This should fix those failures:
https://github.com/std-uritemplate/std-uritemplate/actions/runs/6622553875/job/17988267543?pr=86#step:3:8

Already added the `Dependabot` missing secret in Settings