### PR TITLE
go - check-in go.sum

### DIFF
--- a/go/go.mod
+++ b/go/go.mod
@@ -1,3 +1,11 @@
 module github.com/std-uritemplate/std-uritemplate/go
 
 go 1.20
+
+require github.com/stretchr/testify v1.8.4
+
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
+)

--- a/go/go.sum
+++ b/go/go.sum
@@ -1,0 +1,10 @@
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
+github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=


### PR DESCRIPTION
closes #98
This is a follow up of the discussion in https://github.com/std-uritemplate/std-uritemplate/pull/98

I have a local project that uses `std-urutemplate` where the `go.mod` file looks like:

```
module github.com/lburgazzoli/go-playground

go 1.21.4

require github.com/std-uritemplate/std-uritemplate/go v0.0.47
replace github.com/std-uritemplate/std-uritemplate/go => github.com/lburgazzoli/std-uritemplate/go v0.0.0-20231121095726-2c6578b35250
```

as expected, `testify` is not listed in the `go.mod` but it is listed in the `go.sum`

```
github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
github.com/lburgazzoli/std-uritemplate/go v0.0.0-20231121095726-2c6578b35250 h1:mczz5tt4RDNtdyAqbe8H351vRcGGobjgpM3agcPDDyE=
github.com/lburgazzoli/std-uritemplate/go v0.0.0-20231121095726-2c6578b35250/go.mod h1:CLZ1543WRCuUQQjK0BvPM4QrG2toY8xNZUm8Vbt7vTc=
github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
```

The `testify` is also not referenced in the produced binary: 

```
➜ strings playground | grep testif | wc
       0       0       0
```       

nor in the dependencies the compiler has detected:

```
➜ go list -json | jq '.Deps'
[
  "errors",
  "fmt",
  "github.com/std-uritemplate/std-uritemplate/go",
  "internal/abi",
  "internal/bytealg",
  "internal/coverage/rtcov",
  "internal/cpu",
  "internal/fmtsort",
  "internal/goarch",
  "internal/godebugs",
  "internal/goexperiment",
  "internal/goos",
  "internal/itoa",
  "internal/oserror",
  "internal/poll",
  "internal/race",
  "internal/reflectlite",
  "internal/safefilepath",
  "internal/syscall/execenv",
  "internal/syscall/unix",
  "internal/testlog",
  "internal/unsafeheader",
  "io",
  "io/fs",
  "math",
  "math/bits",
  "net/url",
  "os",
  "path",
  "reflect",
  "runtime",
  "runtime/internal/atomic",
  "runtime/internal/math",
  "runtime/internal/sys",
  "sort",
  "strconv",
  "strings",
  "sync",
  "sync/atomic",
  "syscall",
  "time",
  "unicode",
  "unicode/utf8",
  "unsafe"
]
```

So I think this cope with the `zero additional runtime dependency implementation` and allows to leverage some dev related dependencies to ease the maintenance.