### PR TITLE
Reenable release job for dart

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -197,26 +197,26 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
 
-#  # according to https://dart.dev/tools/pub/automated-publishing#configuring-automated-publishing-from-github-actions-on-pubdev
-#  publish-dart:
-#    permissions:
-#      id-token: write # Required for authentication using OIDC
-#    runs-on: ubuntu-latest
-#    steps:
-#      - uses: actions/checkout@v4
-#      - name: Setup Dart
-#        uses: dart-lang/setup-dart@v1
-#        with:
-#          sdk: stable
-#      - name: Install dependencies
-#        working-directory: dart
-#        run: dart pub get
-#      - name: Prepare Release Files
-#        working-directory: dart
-#        run: |
-#          cp ../Readme.md .
-#          cp ../LICENSE .
-#          sed -i 's/version:.*/version: ${GITHUB_REF_NAME}/' pubspec.yaml
-#      - name: Release to pub.dev
-#        working-directory: dart
-#        run: dart pub publish --force
+  # according to https://dart.dev/tools/pub/automated-publishing#configuring-automated-publishing-from-github-actions-on-pubdev
+  publish-dart:
+    permissions:
+      id-token: write # Required for authentication using OIDC
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Dart
+        uses: dart-lang/setup-dart@v1
+        with:
+          sdk: stable
+      - name: Install dependencies
+        working-directory: dart
+        run: dart pub get
+      - name: Prepare Release Files
+        working-directory: dart
+        run: |
+          cp ../Readme.md .
+          cp ../LICENSE .
+          sed -i 's/version:.*/version: ${GITHUB_REF_NAME}/' pubspec.yaml
+      - name: Release to pub.dev
+        working-directory: dart
+        run: dart pub publish --force


### PR DESCRIPTION
Based on the comment in https://github.com/std-uritemplate/std-uritemplate/pull/124#pullrequestreview-1869751555, we decided to create a follow-up PR for enabling dart publishing. This is that PR.

@andreaTP requested a free subdomain to be used as a verified publisher for pub.dev.