### PR TITLE
reomves use of nodejs API

### DIFF
--- a/typescript/src/index.ts
+++ b/typescript/src/index.ts
@@ -298,7 +298,7 @@ export class StdUriTemplate {
         reservedBuffer = [];
       }
 
-      let toAppend: string = Buffer.from(character, 'utf-8').toString();
+      let toAppend: string = character;
       if (StdUriTemplate.isSurrogate(character)) {
           toAppend = encodeURIComponent(stringValue.charAt(i) + stringValue.charAt(i + 1));
           i++; // Skip the next character


### PR DESCRIPTION
initially reported https://github.com/microsoft/kiota/issues/4165
Buffer.from [is a nodeJS only API](https://nodejs.org/api/buffer.html#static-method-bufferfromstring-encoding) and is not available in browsers.
From reading the code, it seems its use was unecessary, but @andreaTP can confirm this.