### PR TITLE
Add generated release configuration

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,33 @@
+changelog:
+  exclude:
+    labels:
+      - ignore-for-release
+      - wontfix
+      - invalid
+      - question
+      - duplicate
+      - github-actions
+  categories:
+    - title: Breaking Changes 🛠
+      labels:
+        - breaking-change
+    - title: New Features 🎉
+      labels:
+        - enhancement
+    - title: New Language Support ✨
+      labels:
+        - new-lang
+    - title: Bug Fixes 🐛
+      labels:
+        - bug
+    - title: Other Changes
+      labels:
+        - "*"
+      exclude:
+        labels:
+          - dependencies
+          - submodules
+    - title: Dependencies 📦
+      labels:
+        - dependencies
+        - submodules

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -246,7 +246,7 @@ jobs:
           cp ../LICENSE .
           cat <<< $(yq e -M ".version = \"${GITHUB_REF_NAME}\"" pubspec.yaml) > pubspec.yaml
       - name: Generate Changelog
-        uses: ricardoboss/changelog-from-github-releases@v1
+        uses: ricardoboss/changelog-from-github-releases@v1.0.0
         with:
           file: dart/CHANGELOG.md
       - name: Release dry run

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -114,7 +114,7 @@ jobs:
       - name: Generate Changelog
         uses: rhysd/changelog-from-release/action@v3
         with:
-          args: -d false
+          args: -d=false
           file: csharp/CHANGELOG.md
           github_token: ${{ secrets.GITHUB_TOKEN }}
       - name: Package the release
@@ -250,7 +250,7 @@ jobs:
       - name: Generate Changelog
         uses: rhysd/changelog-from-release/action@v3
         with:
-          args: -d false
+          args: -d=false
           file: dart/CHANGELOG.md
           github_token: ${{ secrets.GITHUB_TOKEN }}
       - name: Release dry run

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -116,6 +116,7 @@ jobs:
         with:
           args: -d=false
           file: csharp/CHANGELOG.md
+          commit: false
           github_token: ${{ secrets.GITHUB_TOKEN }}
       - name: Package the release
         working-directory: csharp
@@ -252,6 +253,7 @@ jobs:
         with:
           args: -d=false
           file: dart/CHANGELOG.md
+          commit: false
           github_token: ${{ secrets.GITHUB_TOKEN }}
       - name: Release dry run
         working-directory: dart

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -112,9 +112,11 @@ jobs:
         with:
           dotnet-version: 8
       - name: Generate Changelog
-        uses: ricardoboss/changelog-from-github-releases@v1.0.0
+        uses: rhysd/changelog-from-release/action@v3
         with:
+          args: -d false
           file: csharp/CHANGELOG.md
+          github_token: ${{ secrets.GITHUB_TOKEN }}
       - name: Package the release
         working-directory: csharp
         shell: pwsh
@@ -246,9 +248,11 @@ jobs:
           cp ../LICENSE .
           cat <<< $(yq e -M ".version = \"${GITHUB_REF_NAME}\"" pubspec.yaml) > pubspec.yaml
       - name: Generate Changelog
-        uses: ricardoboss/changelog-from-github-releases@v1.0.0
+        uses: rhysd/changelog-from-release/action@v3
         with:
+          args: -d false
           file: dart/CHANGELOG.md
+          github_token: ${{ secrets.GITHUB_TOKEN }}
       - name: Release dry run
         working-directory: dart
         run: dart pub publish --dry-run

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -114,7 +114,6 @@ jobs:
       - name: Generate Changelog
         uses: rhysd/changelog-from-release/action@v3
         with:
-          args: -d=false
           file: csharp/CHANGELOG.md
           commit: false
           github_token: ${{ secrets.GITHUB_TOKEN }}
@@ -251,7 +250,6 @@ jobs:
       - name: Generate Changelog
         uses: rhysd/changelog-from-release/action@v3
         with:
-          args: -d=false
           file: dart/CHANGELOG.md
           commit: false
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -111,6 +111,10 @@ jobs:
         uses: actions/setup-dotnet@v4
         with:
           dotnet-version: 8
+      - name: Generate Changelog
+        uses: ricardoboss/changelog-from-github-releases@v1
+        with:
+          file: csharp/CHANGELOG.md
       - name: Package the release
         working-directory: csharp
         shell: pwsh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -240,8 +240,9 @@ jobs:
         run: |
           cp ../Readme.md ./README.md
           cp ../LICENSE .
-          echo "${GITHUB_REF_NAME}" > CHANGELOG.md
           cat <<< $(yq e -M ".version = \"${GITHUB_REF_NAME}\"" pubspec.yaml) > pubspec.yaml
+      - name: Generate Changelog
+        uses: ricardoboss/changelog-from-github-releases@v1
       - name: Release dry run
         working-directory: dart
         run: dart pub publish --dry-run

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -243,6 +243,8 @@ jobs:
           cat <<< $(yq e -M ".version = \"${GITHUB_REF_NAME}\"" pubspec.yaml) > pubspec.yaml
       - name: Generate Changelog
         uses: ricardoboss/changelog-from-github-releases@v1
+        with:
+          file: dart/CHANGELOG.md
       - name: Release dry run
         working-directory: dart
         run: dart pub publish --dry-run

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -112,7 +112,7 @@ jobs:
         with:
           dotnet-version: 8
       - name: Generate Changelog
-        uses: ricardoboss/changelog-from-github-releases@v1
+        uses: ricardoboss/changelog-from-github-releases@v1.0.0
         with:
           file: csharp/CHANGELOG.md
       - name: Package the release


### PR DESCRIPTION
...and generate a CHANGELOG.md for certain packages.

This PR should fix #198 as this automates including the CHANGELOG in packages and makes it easier to manage releases via GitHub.

Future PRs will need to be tagged correctly and I have taken the liberty to add new tags (`ignore-for-release` and `breaking-change`) that can be used to categorize them in the releases.

You might also notice that I have created a new GitHub action just to generate the CHANGELOG.md from the GitHub releases, as I was unable to find such an action. It just fetches the releases from GitHub, takes their markdown bodies and writes them all into a file.

I only added the generation for Dart and C# since I already know how to include them in their respective packages.

---

For the future, it might also be interesting to look into an auto-labeller action that adds relevant labels to PRs based on the changed files (`.github/workflows/*` -> `github-actions` label, `dart/*` -> `dart` label, etc...).