### PR TITLE
Cancel in-progress CodeQL actions

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -8,6 +8,11 @@ on:
   schedule:
     - cron: '30 7 * * 4'
 
+concurrency:
+  # Only run once for latest commit per ref and cancel other (previous) runs.
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   analyze:
     name: Analyze (${{ matrix.language }})


### PR DESCRIPTION
CodeQL actions are taking forever to execute and they easily clog the available runners.
This should help.