### PR TITLE
fix/npm license

### DIFF
--- a/typescript/package-lock.json
+++ b/typescript/package-lock.json
@@ -2853,12 +2853,13 @@
       }
     },
     "node_modules/micromatch": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
-      "integrity": "sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==",
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "braces": "^3.0.2",
+        "braces": "^3.0.3",
         "picomatch": "^2.3.1"
       },
       "engines": {

--- a/typescript/package-lock.json
+++ b/typescript/package-lock.json
@@ -7,7 +7,7 @@
     "": {
       "name": "@std-uritemplate/std-uritemplate",
       "version": "0.0.1",
-      "license": "APACHE2",
+      "license": "Apache-2.0",
       "devDependencies": {
         "puppeteer": "^23.0.1",
         "rimraf": "^6.0.0",

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -12,7 +12,7 @@
     "std-uritemplate"
   ],
   "author": "Andrea Peruffo <andrea.peruffo1982@gmail.com>",
-  "license": "APACHE2",
+  "license": "Apache-2.0",
   "type": "module",
   "exports": {
     ".": {


### PR DESCRIPTION
SPDX was wrong, see the id here https://spdx.org/licenses/Apache-2.0.html
This is in turns causing clearlydefined to fail, which in turns triggers warnings in our internal pipelines. https://clearlydefined.io/definitions/npm/npmjs/@std-uritemplate/std-uritemplate/1.0.5