### PR TITLE
Workaround Dart checks for publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -304,6 +304,7 @@ jobs:
         run: |
           cp ../Readme.md ./README.md
           cp ../LICENSE .
+          echo "Release version: ${GITHUB_REF_NAME}" >> CHANGELOG.md
           cat <<< $(yq e -M ".version = \"${GITHUB_REF_NAME}\"" pubspec.yaml) > pubspec.yaml
       - name: Release dry run
         working-directory: dart

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,6 +20,9 @@ jobs:
         uses: softprops/action-gh-release@v2
         with:
           token: ${{ secrets.GH_TOKEN }}
+      # We faced problem like: https://github.com/cli/cli/issues/6599
+      - name: Sleep for 60 seconds
+        run: sleep 60
       # Changelog is generated from GH releases
       - name: Generate Changelog
         uses: rhysd/changelog-from-release/action@v3


### PR DESCRIPTION
@ricardoboss the 2.0.0 release of this library failed for Dart:
https://github.com/std-uritemplate/std-uritemplate/actions/runs/11102463089/job/30842617994

I believe that it's because of some "flaky" behavior of `changelog-from-release`, e.g. not detecting the latest GH release.
This is a plain workaround to make sure that we still publish even if the Changelog is outdated.

Happy to review the automation if anyone finds a more robust tool to generate the changelog.