### PR TITLE
Fix the Go release keeping compatibility with v1

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -103,13 +103,13 @@ StdUriTemplate.expand(template, substitutions);
 Install the package:
 
 ```bash
-go get github.com/std-uritemplate/std-uritemplate/go
+go get github.com/std-uritemplate/std-uritemplate/go/v2
 ```
 
 and use it:
 
 ```go
-import stduritemplate "github.com/std-uritemplate/std-uritemplate/go"
+import stduritemplate "github.com/std-uritemplate/std-uritemplate/go/v2"
 
 ...
 

--- a/go/init.sh
+++ b/go/init.sh
@@ -7,7 +7,7 @@ SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
   cd ${SCRIPT_DIR}/test && \
   rm -f go.mod stduritemplate && \
   go mod init stduritemplate && \
-  go mod edit -replace github.com/std-uritemplate/std-uritemplate/go=../ && \
+  go mod edit -replace github.com/std-uritemplate/std-uritemplate/go/v2=../v2 && \
   go mod tidy && \
   go build
 )

--- a/go/test/test.go
+++ b/go/test/test.go
@@ -6,7 +6,7 @@ import (
 	"os"
 	"strings"
 
-	stduritemplate "github.com/std-uritemplate/std-uritemplate/go"
+	stduritemplate "github.com/std-uritemplate/std-uritemplate/go/v2"
 )
 
 func main() {

--- a/go/v2/go.mod
+++ b/go/v2/go.mod
@@ -1,0 +1,11 @@
+module github.com/std-uritemplate/std-uritemplate/go/v2
+
+go 1.20
+
+require github.com/stretchr/testify v1.9.0
+
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
+)

--- a/go/v2/go.sum
+++ b/go/v2/go.sum
@@ -1,0 +1,10 @@
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=
+github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/go/v2/stduritemplate.go
+++ b/go/v2/stduritemplate.go
@@ -6,7 +6,6 @@ import (
 	"sort"
 	"strconv"
 	"strings"
-	"time"
 	"unicode/utf8"
 )
 
@@ -326,11 +325,11 @@ func getSubstitutionType(value any, col int) string {
 	switch value.(type) {
 	case nil:
 		return SubstitutionTypeEmpty
-	case string, float32, float64, int, int8, int16, int32, int64, bool, time.Time:
+	case string, float32, float64, int, int8, int16, int32, int64, bool:
 		return SubstitutionTypeString
-	case []string, []float32, []float64, []int, []int8, []int16, []int32, []int64, []bool, []time.Time, []any:
+	case []string, []float32, []float64, []int, []int8, []int16, []int32, []int64, []bool, []any:
 		return SubstitutionTypeList
-	case map[string]string, map[string]float32, map[string]float64, map[string]int, map[string]int8, map[string]int16, map[string]int32, map[string]int64, map[string]bool, map[string]time.Time, map[string]any:
+	case map[string]string, map[string]float32, map[string]float64, map[string]int, map[string]int8, map[string]int16, map[string]int32, map[string]int64, map[string]bool, map[string]any:
 		return SubstitutionTypeMap
 	default:
 		return fmt.Sprintf("illegal class passed as substitution, found %T at col: %d", value, col)
@@ -375,8 +374,6 @@ func getListLength(value any) int {
 		return len(value.([]int64))
 	case []bool:
 		return len(value.([]bool))
-	case []time.Time:
-		return len(value.([]time.Time))
 	case []any:
 		return len(value.([]any))
 	}
@@ -403,8 +400,6 @@ func getMapLength(value any) int {
 		return len(value.(map[string]int64))
 	case map[string]bool:
 		return len(value.(map[string]bool))
-	case map[string]time.Time:
-		return len(value.(map[string]time.Time))
 	case map[string]any:
 		return len(value.(map[string]any))
 	}
@@ -480,14 +475,6 @@ func convertNativeList(value any) ([]string, error) {
 		}
 	case []bool:
 		for index, val := range value.([]bool) {
-			str, err := convertNativeTypes(val)
-			if err != nil {
-				return nil, err
-			}
-			stringList[index] = str
-		}
-	case []time.Time:
-		for index, val := range value.([]time.Time) {
 			str, err := convertNativeTypes(val)
 			if err != nil {
 				return nil, err
@@ -583,14 +570,6 @@ func convertNativeMap(value any) (map[string]string, error) {
 			}
 			stringMap[key] = str
 		}
-	case map[string]time.Time:
-		for key, val := range value.(map[string]time.Time) {
-			str, err := convertNativeTypes(val)
-			if err != nil {
-				return nil, err
-			}
-			stringMap[key] = str
-		}
 	case map[string]any:
 		for key, val := range value.(map[string]any) {
 			str, err := convertNativeTypes(val)
@@ -609,8 +588,6 @@ func convertNativeTypes(value any) (string, error) {
 	switch value.(type) {
 	case string, float32, float64, int, int8, int16, int32, int64, bool:
 		return fmt.Sprintf("%v", value), nil
-	case time.Time:
-		return value.(time.Time).Format(time.RFC3339), nil
 	default:
 		return "", fmt.Errorf("unrecognized type: %s", value)
 	}

--- a/go/v2/stduritemplate_test.go
+++ b/go/v2/stduritemplate_test.go
@@ -1,0 +1,18 @@
+package stduritemplate
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestExpandStringArray(t *testing.T) {
+	urlTemplate := "{+baseurl}/users{?statuses}"
+	data := map[string]interface{}{
+		"baseurl":  "https://example.com",
+		"statuses": []string{"active", "pending"},
+	}
+	result, err := Expand(urlTemplate, data)
+	assert.Nil(t, err)
+	assert.Equal(t, "https://example.com/users?statuses=active,pending", result)
+}


### PR DESCRIPTION
Here I basically followed the pattern described here:

https://stackoverflow.com/a/53380636/7898052

in the section "Subdirectories".
Since Go is directly consumed from the monorepo, I think this is the best approach.

cc. @evacchi that suggested this solution :pray: 