### PR TITLE
feat(actions): add nuget trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -139,6 +139,8 @@ jobs:
   publish-csharp:
     runs-on: windows-latest # Code signing must run on a Windows agent for Authenticode signing (dll/exe)
     needs: publish-gh-releases
+    permissions:
+      id-token: write
     steps:
       - uses: actions/checkout@v4
         with:
@@ -180,11 +182,16 @@ jobs:
           --azure-key-vault-url "${{ secrets.DOTNET_VAULT_URL }}"
           --timestamp-url http://timestamp.digicert.com
           --verbosity Debug
+      - name: NuGet login
+        uses: NuGet/login@v1
+        id: nuget-login
+        with:
+          user: ${{ secrets.NUGET_USER }}
       - name: Release to NuGet
         working-directory: csharp
         shell: pwsh
         run: |
-          dotnet nuget push "${{ github.workspace }}\csharp\dist\Std.UriTemplate.${{ github.ref_name }}.nupkg" --api-key "${{ secrets.NUGET_TOKEN }}" --source https://api.nuget.org/v3/index.json
+          dotnet nuget push "${{ github.workspace }}\csharp\dist\Std.UriTemplate.${{ github.ref_name }}.nupkg" --api-key "${{ steps.nuget-login.outputs.NUGET_API_KEY }}" --source https://api.nuget.org/v3/index.json
 
   publish-ruby:
     runs-on: ubuntu-latest


### PR DESCRIPTION
###
fixes #373 

#### Motivation

As described in [the official announcement](https://devblogs.microsoft.com/dotnet/enhanced-security-is-here-with-the-new-trust-publishing-on-nuget-org/), the new **Trusted Publishing** feature greatly enhances package publishing security on NuGet.org.

We successfully tested this approach with our own NuGet library:

- [GitHub Actions run example](https://github.com/micheloliveira-com/ReactiveLock/actions/runs/18042183860/workflow)  
- [Corresponding commit](https://github.com/micheloliveira-com/ReactiveLock/blob/a9353d6ddc7cb45f386e816c6ab5ea2837bd1513/.github/workflows/k6-test-multi.yml)

#### Required changes in this repository

> **Recommendation followed from announcement:**  
> For security, always use a GitHub secret like `${{ secrets.NUGET_USER }}` for your NuGet.org username (profile name), **not your email address**.

- Add `secrets.NUGET_USER` to this repository, using the **NuGet.org username (profile name)** of the package owner (
Std.UriTemplate in this case).  
- The old `secrets.NUGET_TOKEN` secret can be removed from this repository **and also from the NuGet.org account** if it was only used here.  

#### One-time configuration on NuGet.org

According to the documentation:

1. Sign in to NuGet.org.  
2. Open your user menu (top-right) → **Trusted Publishing** (next to “API Keys”).  
3. Create a policy:  
   - **Package owner:** you or your organization (e.g. `Std.UriTemplate`).  
   - **Repository owner:** your GitHub org/user (e.g. `std-uritemplate`).  
   - **Repository name:** repository name (e.g. `std-uritemplate`).  
   - **Workflow file:** the YAML file under `.github/workflows/` (e.g. `release.yml`).  
   - **Environment (optional):** specify if your workflow uses GitHub Actions environments.

This setup eliminates the need for long-lived API keys and improves the overall security of the publishing process.